### PR TITLE
More instantiation options

### DIFF
--- a/human-view-switcher.js
+++ b/human-view-switcher.js
@@ -10,6 +10,9 @@ function ViewSwitcher(el, options) {
         this.config[item] = options[item];
     }
     this.current = null;
+    if (options.view) {
+        this.set(options.view);
+    }
 }
 
 ViewSwitcher.prototype.set = function (view) {
@@ -29,6 +32,7 @@ ViewSwitcher.prototype.set = function (view) {
         this._hide(prev);
         this._show(current);
     }
+    return this;
 };
 
 ViewSwitcher.prototype._show = function (view, cb) {


### PR DESCRIPTION
Return this on .set and also add a view option so I can do this:

``` javascript
var mySwitcher = new ViewSwitcher(this.getByRole('cat')).set(catSubview);
```

or this (according to preference, it's easy to support both)

``` javascript
var mySwitcher = new ViewSwitcher(this.getByRole('cat'), {view: catSubview});
```
